### PR TITLE
Disable hugepage compaction, versus disabling transparent hugepages

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -202,5 +202,5 @@ template "/usr/lib/hadoop-#{node[:hadoop][:version]}/bin/hadoop-config.sh" do
 end
 
 execute "update hadoop alternatives" do
-  command "alternatives --install /etc/hadoop-#{node[:hadoop][:version]}/conf hadoop-#{node[:hadoop][:version]}-conf /etc/hadoop-#{node[:hadoop][:version]}/#{node[:hadoop][:conf_dir]} 50"
+  command "update-alternatives --install /etc/hadoop-#{node[:hadoop][:version]}/conf hadoop-#{node[:hadoop][:version]}-conf /etc/hadoop-#{node[:hadoop][:version]}/#{node[:hadoop][:conf_dir]} 50"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -202,5 +202,5 @@ template "/usr/lib/hadoop-#{node[:hadoop][:version]}/bin/hadoop-config.sh" do
 end
 
 execute "update hadoop alternatives" do
-  command "update-alternatives --install /etc/hadoop-#{node[:hadoop][:version]}/conf hadoop-#{node[:hadoop][:version]}-conf /etc/hadoop-#{node[:hadoop][:version]}/#{node[:hadoop][:conf_dir]} 50"
+  command "alternatives --install /etc/hadoop-#{node[:hadoop][:version]}/conf hadoop-#{node[:hadoop][:version]}-conf /etc/hadoop-#{node[:hadoop][:version]}/#{node[:hadoop][:conf_dir]} 50"
 end

--- a/templates/default/hadoop-0.20-datanode.erb
+++ b/templates/default/hadoop-0.20-datanode.erb
@@ -43,9 +43,11 @@ desc="Hadoop datanode daemon"
 SLEEP_TIME=5
 
 start() {
+  <%- if node['kernel']['release'].to_i >= 3 -%>
   #this will disable Transparent Hugepage Support
   #http://www.mjmwired.net/kernel/Documentation/vm/transhuge.txt
   echo 'never' > /sys/kernel/mm/redhat_transparent_hugepage/defrag
+  <%- end -%>
   echo -n $"Starting $desc (hadoop-datanode): "
   daemon /usr/lib/hadoop-0.20/bin/hadoop-daemon.sh --config "/etc/hadoop-0.20/conf" start datanode $DAEMON_FLAGS
   RETVAL=$?

--- a/templates/default/hadoop-0.20-datanode.erb
+++ b/templates/default/hadoop-0.20-datanode.erb
@@ -45,7 +45,7 @@ SLEEP_TIME=5
 start() {
   #this will disable Transparent Hugepage Support
   #http://www.mjmwired.net/kernel/Documentation/vm/transhuge.txt
-  echo 'never' > /sys/kernel/mm/redhat_transparent_hugepage/enabled
+  echo 'never' > /sys/kernel/mm/redhat_transparent_hugepage/defrag
   echo -n $"Starting $desc (hadoop-datanode): "
   daemon /usr/lib/hadoop-0.20/bin/hadoop-daemon.sh --config "/etc/hadoop-0.20/conf" start datanode $DAEMON_FLAGS
   RETVAL=$?


### PR DESCRIPTION
Switch from disabling transparent hugepages entirely, to only disabling compaction, as this will give us back the performance of using hugepages. Also, only do this on machines with kernel 3.0+ as older kernels don't support it (and we don't like useless error messages)...
